### PR TITLE
Fix the way to get runtimepath is changed

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_zsh.py
+++ b/rplugin/python3/deoplete/sources/deoplete_zsh.py
@@ -24,7 +24,7 @@ class Source(Base):
         return m.start()
 
     def gather_candidates(self, context):
-        capture = globruntime(context['runtimepath'], 'bin/capture.zsh')
+        capture = globruntime(self.vim.options['runtimepath'], 'bin/capture.zsh')
         if not self.__executable_zsh or not capture or not context['input']:
             return []
 


### PR DESCRIPTION
context: drop "runtimepath"
`vim.options['runtimepath']` can be used instead if necessary.

https://github.com/Shougo/deoplete.nvim/commit/e0923e48441502cee7d351e2b678cd50febaf506