### PR TITLE
completion style overrides readline prompt if toomany completions

### DIFF
--- a/bin/capture.zsh
+++ b/bin/capture.zsh
@@ -43,10 +43,15 @@ comppostfuncs=( null-line exit )
 
 # never group stuff!
 zstyle '':completion:*'' list-grouped false
+zstyle '':completion:*'' force-list always
 # don''t insert tab when attempting completion on empty line
 zstyle '':completion:*'' insert-tab false
 # no list separator, this saves some stripping later on
 zstyle '':completion:*'' list-separator ''''
+# for list even if too many
+zstyle '':completion:*'' list-prompt   ''''
+zstyle '':completion:*'' select-prompt ''''
+zstyle '':completion:*'' menu true
 
 # we use zparseopts
 zmodload zsh/zutil

--- a/rplugin/python3/deoplete/sources/deoplete_zsh.py
+++ b/rplugin/python3/deoplete/sources/deoplete_zsh.py
@@ -6,40 +6,42 @@ from .base import Base
 
 
 class Source(Base):
-
     def __init__(self, vim):
         Base.__init__(self, vim)
 
-        self.name = 'zsh'
-        self.mark = '[zsh]'
-        self.filetypes = ['zsh']
-        self.input_pattern = '[^. \t0-9]\.\w*'
+        self.name = "zsh"
+        self.mark = "[zsh]"
+        self.filetypes = ["zsh"]
+        self.input_pattern = r"[^. \t0-9][.\w]*"
         self.rank = 500
-        self.__executable_zsh = self.vim.call('executable', 'zsh')
+        self.__executable_zsh = self.vim.call("executable", "zsh")
 
     def get_complete_position(self, context):
-        m = re.search(r'\S+$', context['input'])
+        m = re.search(r"\S+$", context["input"])
         if not m:
             return -1
         return m.start()
 
     def gather_candidates(self, context):
-        capture = globruntime(self.vim.options['runtimepath'],
-                              'bin/capture.zsh')
-        if not self.__executable_zsh or not capture or not context['input']:
+        capture = globruntime(self.vim.options["runtimepath"], "bin/capture.zsh")
+        if not self.__executable_zsh or not capture or not context["input"]:
             return []
 
         result = []
         try:
-            for pieces in [x.decode(context['encoding']).split(' -- ')
-                           for x in subprocess.check_output(
-                               ['zsh', capture[0], context['input']],
-                               cwd=self.vim.call('getcwd'),
-                               timeout=1.0).splitlines()]:
-                if len(pieces) > 1:
-                    result.append({ 'word': pieces[0], 'menu': pieces[1] })
-                else:
-                    result.append({ 'word': pieces[0] })
+            for pieces in [
+                x.decode(context["encoding"]).rpartition(" -- ")
+                for x in subprocess.check_output(
+                    ["zsh", capture[0], context["input"]],
+                    cwd=self.vim.call("getcwd"),
+                    timeout=1.2,
+                ).splitlines()
+            ]:
+                if not pieces[1]:
+                    result.append({"word": pieces[-1].strip()})
+                if pieces[-1].strip():
+                    for piece in pieces[0].split():
+                        result.append({"word": piece.strip(), "menu": pieces[-1]})
         except subprocess.SubprocessError:
             return []
         return result


### PR DESCRIPTION
I was having trouble with completions not getting to th emend if too many options.  I added some options to bin/capture.zsh to override the prompt. I'm not sure if this is required or  this works for other people so appreciate feedback